### PR TITLE
Pin python version to 3.7

### DIFF
--- a/drink.py
+++ b/drink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.7
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
change shebang from python3 to python3.7 beacuse we need a new feature of deepcopy.